### PR TITLE
admin dashboard changed

### DIFF
--- a/src/features/dashboard/components/dashboard.tsx
+++ b/src/features/dashboard/components/dashboard.tsx
@@ -8,12 +8,16 @@ import {
   TaskCardSkeleton,
   WelcomeHeader,
 } from '@/features/dashboard'
-
+import { UserRole } from '@/types'
 export function Dashboard() {
   const { t } = useTranslation('dashboard')
   const navigate = useNavigate()
   const { currentUser } = useAuth()
-  const { data: task, isLoading } = useGetAssignedTask(currentUser?.id)
+  const isAdmin = currentUser?.role === UserRole.Admin
+  const { data: task, isLoading } = useGetAssignedTask(
+    isAdmin ? undefined : currentUser?.id
+  )
+
 
   if (!currentUser) return null
 
@@ -24,7 +28,7 @@ export function Dashboard() {
   return (
     <div className="space-y-8 animate-fade-in">
       <WelcomeHeader user={currentUser} />
-
+    {!isAdmin && (
       <div className="space-y-4">
         <h2 className="text-xl font-semibold">{t('currentTask')}</h2>
 
@@ -36,6 +40,8 @@ export function Dashboard() {
           <TaskCard task={task} onContinue={handleContinue} />
         )}
       </div>
+      )}
     </div>
+    
   )
 }


### PR DESCRIPTION
### Hide dashboard for admin users

- Prevent admin users from accessing the dashboard
- Avoid unnecessary loading states (skeleton) for admin users
- Added role-based check to stop dashboard rendering for admins