### PR TITLE
Add project documentation (README, architecture, workflows, contribut…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+## Prerequisites
+
+Complete the [Getting Started](docs/getting-started.md) guide before making any changes.
+
+## Branching Strategy
+
+| Branch | Purpose |
+|---|---|
+| `main` | Production-ready code. Direct commits are not allowed. |
+| `feat/<description>` | New feature or enhancement |
+| `fix/<description>` | Bug fix |
+| `chore/<description>` | Dependency updates, tooling, config changes |
+| `docs/<description>` | Documentation-only changes |
+
+Branch from `main`:
+
+```bash
+git checkout main && git pull
+git checkout -b feat/my-feature
+```
+
+## Development Workflow
+
+1. Make your changes in the feature branch.
+2. Run lint before committing:
+   ```bash
+   npm run lint
+   ```
+3. Verify the app builds without errors:
+   ```bash
+   npm run build
+   ```
+4. Push your branch and open a pull request against `main`.
+
+## Pull Request Guidelines
+
+- Keep PRs focused — one logical change per PR.
+- Write a clear title and describe **what** changed and **why** in the body.
+- Link any related issues.
+- Ensure `npm run lint` and `npm run build` both pass before requesting review.
+- At least one approval is required before merging.
+
+## Code Conventions
+
+### TypeScript
+
+- Prefer `interface` for object shapes; use `type` for unions and aliases.
+- Avoid `any`. Use `unknown` when the type is genuinely unknown and narrow it explicitly.
+- Export types from `src/types/` — do not co-locate type definitions with components unless they are truly component-specific.
+
+### Components
+
+- One component per file. File name matches the exported component name in kebab-case (`workspace-editor.tsx` → `export function WorkspaceEditor`).
+- Keep components focused — extract logic into custom hooks when a component grows complex.
+- Use `shadcn/ui` primitives from `src/components/ui/` rather than raw HTML elements for interactive controls.
+
+### Feature Modules
+
+- New features go in `src/features/<feature-name>/`.
+- API calls belong in `src/features/<feature-name>/api/`, not inside components.
+- Use TanStack Query (`useQuery`, `useMutation`) for all data fetching — do not call `apiClient` directly inside components.
+
+### State
+
+- UI-only state (modals, toasts, preferences) → Zustand `useUIStore`.
+- Server/async state → TanStack Query.
+- Local ephemeral state (controlled inputs, toggles) → `useState`.
+
+### Styling
+
+- Use Tailwind utility classes. Avoid inline styles.
+- Use `cn()` (from `src/lib/utils.ts`) to merge conditional class names.
+- Follow the existing design token conventions from `shadcn/ui` (e.g. `bg-primary`, `text-muted-foreground`).
+
+### Internationalization
+
+- All user-visible strings must use the `t()` function from `react-i18next`.
+- Add keys to **both** `src/locales/en/` and `src/locales/bo/` translation files.
+- Choose the appropriate namespace: `common`, `auth`, `admin`, `dashboard`, or `workspace`.
+
+### Naming Conventions
+
+| Thing | Convention | Example |
+|---|---|---|
+| Files | kebab-case | `workspace-editor.tsx` |
+| React components | PascalCase | `WorkspaceEditor` |
+| Hooks | camelCase with `use` prefix | `useEditorDraft` |
+| Types / Interfaces | PascalCase | `AssignedTask` |
+| Constants | UPPER_SNAKE_CASE | `MAX_ZOOM_LEVEL` |
+| Zustand actions | camelCase | `setEditorFontSize` |
+
+## Adding a New Page
+
+1. Create the page component in `src/pages/<section>/`.
+2. Add a lazy import and route entry in `src/routes/app-routes.tsx`.
+3. If the page is role-restricted, wrap it with `<ProtectedRoute allowedRoles={[...]} />`.
+4. Add translations for any new strings in all relevant locale files.
+
+## Adding a New Feature Module
+
+1. Create `src/features/<name>/` with subdirectories `api/`, `components/`, and `hooks/` as needed.
+2. Export public API from an `index.ts` barrel file.
+3. Register the feature's pages in the router.
+4. Add Zod schemas in `src/schema/` if the feature introduces forms.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,75 @@
-# TextAlign - Image-Text Alignment Tool
+# TextAlign
 
-A React-based application for manual text transcription correction with a 3-tier QA pipeline.
+A React-based web application for collaborative image-text transcription correction with a 3-tier quality assurance (QA) pipeline. Teams use it to review and correct noisy or OCR-generated text against source images, with strict role-based workflows ensuring accuracy before final approval.
 
 ## Features
 
-- **3-Tier Quality Assurance Pipeline**
-
-  - **Transcriber**: Receives noisy text and performs initial correction
-  - **Reviewer**: Validates corrections, can approve or reject
-  - **Final Reviewer**: Performs ultimate sanity check for "Gold Standard" approval
-- **Role-Based Dashboards**: Dedicated views for each user type showing pending tasks, rejected items, and completion metrics
-- **Editor Workspace**: Side-by-side comparison of source image (with pan/zoom) and editable text field
-- **State Machine Logic**: Strict tracking of task assignments and rejections with full audit history
+- **3-Tier QA Pipeline** — Annotator → Reviewer → Final Reviewer with full audit trail
+- **Workspace Editor** — Side-by-side image viewer (pan/zoom/TIFF support) and editable text field
+- **Role-Based Dashboards** — Task queues and completion metrics per role
+- **Admin Panel** — Manage users, groups, and task batches
+- **Internationalization** — English and Tibetan (Bodic) UI
+- **Theme Support** — Light, dark, and system-default modes
+- **Keyboard Shortcuts** — `Ctrl/Cmd +/-/0` to zoom, `Ctrl/Cmd+S` to save draft
 
 ## Tech Stack
 
-- **Framework**: Vite + React 18 + TypeScript
-- **Styling**: Tailwind CSS + shadcn/ui components
-- **Routing**: React Router v6
-- **State Management**: Zustand (UI/auth) + TanStack Query (server state)
-- **Image Viewer**: react-zoom-pan-pinch
+| Layer | Technology |
+|---|---|
+| Framework | Vite 7 + React 18 + TypeScript 5.9 |
+| Styling | Tailwind CSS 4 + shadcn/ui (Radix UI) |
+| Routing | React Router v7 |
+| Server state | TanStack Query v5 |
+| UI state | Zustand v5 |
+| Auth | Auth0 (`@auth0/auth0-react`) |
+| Image handling | react-zoom-pan-pinch, utif2 (TIFF) |
+| i18n | i18next + react-i18next |
+| HTTP | Axios |
 
-## Getting Started
-
-### Prerequisites
-
-- Node.js 18+
-- npm or yarn
-
-### Installation
+## Quick Start
 
 ```bash
-# Install dependencies
+# 1. Install dependencies
 npm install
 
-# Start development server
+# 2. Create environment file
+cp .env.example .env   # then fill in values (see docs/getting-started.md)
+
+# 3. Start development server at http://localhost:3000
 npm run dev
-
-# Build for production
-npm run build
 ```
 
-|  |  |  |
-| - | - | - |
+See [docs/getting-started.md](docs/getting-started.md) for full environment variable and Auth0 setup.
 
-```
-span
-```
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Local setup, env vars, Auth0 configuration |
+| [Architecture](docs/architecture.md) | Folder structure, data flow, state management |
+| [Workflows](docs/workflows.md) | User roles, task state machine, QA pipeline |
+| [Contributing](CONTRIBUTING.md) | Branching strategy, PR process, code conventions |
 
 ## Task State Machine
 
 ```
 Pending → InProgress → AwaitingReview → InReview → AwaitingFinalReview → FinalReview → Completed
-                                            ↓                                 ↓
-                                        Rejected ←─────────────────────────────┘
-                                            ↓
-                                        InProgress (re-assigned)
+                                             ↓                                  ↓
+                                         Rejected ←────────────────────────────┘
+                                             ↓
+                                         InProgress (re-assigned)
 ```
+
+Full workflow details: [docs/workflows.md](docs/workflows.md)
 
 ## Keyboard Shortcuts
 
-- `Ctrl/Cmd + +`: Zoom in image
-- `Ctrl/Cmd + -`: Zoom out image
-- `Ctrl/Cmd + 0`: Reset zoom
-- `Ctrl/Cmd + S`: Save draft (in editor)
+| Shortcut | Action |
+|---|---|
+| `Ctrl/Cmd + +` | Zoom in |
+| `Ctrl/Cmd + -` | Zoom out |
+| `Ctrl/Cmd + 0` | Reset zoom |
+| `Ctrl/Cmd + S` | Save draft |
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,155 @@
+# Architecture
+
+## Overview
+
+TextAlign is a React single-page application (SPA). It communicates with an external backend REST API and uses Auth0 for authentication. The frontend is responsible for all UI rendering, role-based routing, and client-side state; no server-side rendering is involved.
+
+```
+┌──────────────────────────────────────────────┐
+│                  Browser                      │
+│                                               │
+│  ┌────────────┐   ┌────────────────────────┐  │
+│  │   Auth0    │   │    TextAlign SPA        │  │
+│  │  (login)   │◄──│  React + Vite + TS     │  │
+│  └────────────┘   └───────────┬────────────┘  │
+└──────────────────────────────-│───────────────┘
+                                │ HTTP (Axios)
+                    ┌───────────▼────────────┐
+                    │    Backend REST API     │
+                    │  (VITE_BASE_URL)        │
+                    └───────────┬────────────┘
+                                │
+                    ┌───────────▼────────────┐
+                    │   AWS S3 (images)       │
+                    │  proxied via /s3-proxy  │
+                    └────────────────────────┘
+```
+
+## Folder Structure
+
+```
+src/
+├── App.tsx                  # Provider composition root
+├── main.tsx                 # Entry point, React DOM render
+│
+├── components/
+│   ├── common/              # App-wide shared components (ThemeProvider)
+│   ├── layout/              # Page shells (MainLayout, AuthLayout)
+│   └── ui/                  # shadcn/ui primitives (Button, Dialog, etc.)
+│
+├── features/                # Domain slices — each owns its API, components, hooks
+│   ├── auth/                # Auth0 login flow, callback, pending approval
+│   ├── dashboard/           # Role-specific task queues and metrics
+│   ├── workspace/           # Core editor (image viewer + text editor)
+│   └── admin/               # User, group, and batch management
+│
+├── pages/                   # Thin page components — compose feature modules
+│   ├── auth/
+│   ├── dashboard/
+│   ├── workspace/
+│   └── admin/
+│
+├── routes/
+│   ├── app-routes.tsx       # Router config with lazy-loaded pages
+│   └── protected-route.tsx  # Role-based route guard
+│
+├── lib/
+│   ├── axios.ts             # Axios instance (baseURL, 401 handling)
+│   ├── auth.ts              # Auth0 helper utilities
+│   ├── i18n.ts              # i18next initialization
+│   ├── constant.ts          # App-wide constants
+│   ├── date-utils.ts        # Date formatting helpers
+│   └── utils.ts             # General utilities (cn, etc.)
+│
+├── store/
+│   └── use-ui-store.ts      # Zustand store (theme, language, editor prefs, toasts)
+│
+├── types/                   # TypeScript interfaces and enums
+│   ├── task.ts              # TaskStatus, TaskAction, Task, AssignedTask
+│   ├── user.ts              # UserRole, User, UserContribution
+│   ├── group.ts             # Group
+│   ├── batch.ts             # Batch
+│   └── api.ts               # Generic API response wrappers
+│
+├── schema/                  # Zod validation schemas (form inputs)
+│   ├── batch-schema.ts
+│   ├── group-schema.ts
+│   └── user-schema.ts
+│
+├── hooks/                   # Shared React hooks
+│   ├── use-debounced-value.ts
+│   └── use-language-sync.ts
+│
+└── locales/
+    ├── en/                  # English translations (common, auth, admin, dashboard, workspace)
+    └── bo/                  # Tibetan translations (same keys)
+```
+
+## Key Architectural Decisions
+
+### Feature-First Organization
+
+Code is organized by domain feature (`features/auth`, `features/workspace`, etc.) rather than by technical layer. Each feature owns its:
+- API calls (`features/*/api/`)
+- UI components (`features/*/components/`)
+- Custom hooks (`features/*/hooks/`)
+
+Pages in `pages/` are intentionally thin — they import and compose feature modules.
+
+### State Management Split
+
+Two state layers coexist by design:
+
+| Store | Library | Purpose |
+|---|---|---|
+| UI store | Zustand | Theme, language, editor font/size, sidebar, toasts, modal state |
+| Server state | TanStack Query | API data, caching, background refetching, mutations |
+
+Zustand state is persisted to `localStorage` under the key `ui-storage` (theme, language, editor preferences). Server state is never persisted — TanStack Query's 5-minute stale time governs cache freshness.
+
+### Routing and Auth Guards
+
+`ProtectedRoute` wraps every authenticated route. It checks:
+1. Auth0 authentication status
+2. User role (for role-restricted routes like `/admin/*` and `/workspace`)
+
+Unauthenticated users are redirected to `/login`. Authenticated users without a role land on `/pending-approval`.
+
+Route paths and their role requirements:
+
+| Path | Allowed Roles |
+|---|---|
+| `/dashboard` | All authenticated users |
+| `/workspace` | Annotator, Reviewer, Final Reviewer |
+| `/admin/users` | Admin |
+| `/admin/groups` | Admin |
+| `/admin/batches` | Admin |
+| `/admin/batch/:batchId` | Admin |
+
+All pages are lazy-loaded via `React.lazy()` with `Suspense` for code splitting.
+
+### HTTP Client
+
+A single Axios instance is created in `lib/axios.ts` with:
+- `baseURL` from `VITE_BASE_URL`
+- A response interceptor that unwraps `.data` and handles 401s
+
+All API calls go through this instance, keeping auth and error handling centralized.
+
+### S3 Image Proxy
+
+The Vite dev server proxies `/s3-proxy/*` to `https://s3.us-east-1.amazonaws.com` to avoid CORS issues when loading task images locally. In production, configure your hosting layer (reverse proxy or CDN) to replicate this rewrite.
+
+### Internationalization
+
+i18n is handled by `i18next`. Translations are split into five namespaces per locale: `common`, `auth`, `admin`, `dashboard`, `workspace`. The active language is stored in Zustand (persisted to localStorage) and synced to i18next via the `use-language-sync` hook.
+
+Supported locales: `en` (English), `bo` (Tibetan/Bodic).
+
+### Editor Customization
+
+Users can configure their workspace editor via the UI store:
+- **Font family**: `monlam`, `monlam-2`, `noto-black`, `noto-bold`, `noto-medium`, `noto-regular`, `noto-semibold`
+- **Font size**: 14, 16, 18, 20 (default), 24, 28, 32 px
+
+These preferences are persisted across sessions via Zustand's `persist` middleware.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,107 @@
+# Getting Started
+
+This guide walks a new developer through setting up TextAlign locally from scratch.
+
+## Prerequisites
+
+- **Node.js** 18 or later ([download](https://nodejs.org))
+- **npm** 9+ (bundled with Node)
+- An **Auth0** account and application (see [Auth0 Setup](#auth0-setup) below)
+- Access to the backend API (deployed separately)
+
+## 1. Clone and Install
+
+```bash
+git clone <repo-url>
+cd image-transcription
+npm install
+```
+
+## 2. Environment Variables
+
+Create a `.env` file at the project root. The app will not start correctly without these values.
+
+```env
+# Base URL of the backend REST API
+VITE_BASE_URL=http://localhost:8000
+
+# Auth0 credentials (from your Auth0 application dashboard)
+VITE_AUTH0_DOMAIN=your-tenant.auth0.com
+VITE_AUTH0_CLIENT_ID=your-client-id
+VITE_AUTH0_AUDIENCE=your-api-audience
+```
+
+| Variable | Description |
+|---|---|
+| `VITE_BASE_URL` | Backend API base URL. Defaults to `http://localhost:3000` if omitted. |
+| `VITE_AUTH0_DOMAIN` | Your Auth0 tenant domain (e.g. `dev-xxxx.us.auth0.com`). |
+| `VITE_AUTH0_CLIENT_ID` | Client ID from your Auth0 Single Page Application. |
+| `VITE_AUTH0_AUDIENCE` | The API identifier registered in Auth0. Required for access tokens. |
+
+> All variables must be prefixed with `VITE_` to be exposed to the browser by Vite.
+
+## 3. Auth0 Setup
+
+### Create a Single Page Application
+
+1. Go to **Auth0 Dashboard → Applications → Create Application**.
+2. Choose **Single Page Application**.
+3. Note the **Domain** and **Client ID** — these go into `.env`.
+
+### Configure Allowed URLs
+
+In the application settings, set the following (adjust port/domain for production):
+
+| Setting | Value |
+|---|---|
+| Allowed Callback URLs | `http://localhost:3000/callback` |
+| Allowed Logout URLs | `http://localhost:3000/login` |
+| Allowed Web Origins | `http://localhost:3000` |
+
+### Register an API (for access tokens)
+
+1. Go to **Auth0 Dashboard → Applications → APIs → Create API**.
+2. Set an **Identifier** (this becomes `VITE_AUTH0_AUDIENCE`).
+3. Enable **RBAC** and **Add Permissions in the Access Token** in the API settings.
+
+### User Roles
+
+The backend expects users to carry one of these roles in their Auth0 profile. Assign roles to users via **Auth0 Dashboard → User Management → Users → Roles**.
+
+| Role | Slug |
+|---|---|
+| Admin | `admin` |
+| Annotator | `annotator` |
+| Reviewer | `reviewer` |
+| Final Reviewer | `final reviewer` |
+
+A user who logs in without an assigned role lands on the `/pending-approval` page until an admin grants them a role.
+
+## 4. Run the Development Server
+
+```bash
+npm run dev
+```
+
+Opens at **http://localhost:3000**.
+
+The dev server proxies `/s3-proxy/*` requests to `https://s3.us-east-1.amazonaws.com` so that task images served from S3 load without CORS issues during local development.
+
+## 5. Available Scripts
+
+| Script | Description |
+|---|---|
+| `npm run dev` | Start dev server at `http://localhost:3000` |
+| `npm run build` | Compile TypeScript and bundle for production (output: `dist/`) |
+| `npm run preview` | Serve the production build locally at `http://localhost:10000` |
+| `npm run lint` | Run ESLint across the `src/` directory |
+
+## 6. Mocking (Optional)
+
+The project ships with [MSW (Mock Service Worker)](https://mswjs.io/) configured for local development. If you want to run the frontend without a live backend, check `src/mocks/` for handler setup and enable MSW in `src/main.tsx`.
+
+## Next Steps
+
+- [Architecture](architecture.md) — understand how the codebase is organized
+- [Workflows](workflows.md) — understand user roles and the task lifecycle
+- [Contributing](../CONTRIBUTING.md) — how to make and submit changes

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,136 @@
+# Workflows
+
+## User Roles
+
+TextAlign has four roles. Each role has a distinct set of permissions and a dedicated dashboard view.
+
+| Role | Slug | Responsibilities |
+|---|---|---|
+| **Admin** | `admin` | Manages users, groups, and batches. Does not participate in transcription. |
+| **Annotator** | `annotator` | Receives tasks with noisy/OCR text. Corrects the text against the source image and submits for review. |
+| **Reviewer** | `reviewer` | Reviews submitted corrections. Can approve (advancing to Final Review) or reject (sending back to the Annotator). |
+| **Final Reviewer** | `final reviewer` | Performs the last quality check. Approval marks a task as Gold Standard (`Completed`). Rejection sends it back to the Annotator. |
+
+A new user who logs in without a role is shown the **Pending Approval** screen and cannot access any features until an Admin assigns them a role.
+
+## Task State Machine
+
+Each task moves through a strict sequence of states. The diagram below shows all valid transitions.
+
+```
+                ┌──────────┐
+                │  Pending  │
+                └────┬──────┘
+                     │ (admin assigns / annotator claims)
+                     ▼
+               ┌────────────┐
+               │ InProgress │◄─────────────────────────────────┐
+               └─────┬──────┘                                  │
+                     │ (annotator submits)                      │
+                     ▼                                          │
+           ┌──────────────────┐                                 │
+           │  AwaitingReview  │                                 │
+           └────────┬─────────┘                                 │
+                    │ (reviewer claims)                          │
+                    ▼                                            │
+              ┌──────────┐                                       │
+              │ InReview  │                                      │
+              └──┬────┬───┘                                      │
+      (approve)  │    │ (reject)                                 │
+                 │    ▼                                          │
+                 │  ┌──────────┐                                 │
+                 │  │ Rejected │─────────────────────────────────┘
+                 │  └──────────┘  (re-assigned to annotator)
+                 ▼
+  ┌────────────────────────┐
+  │  AwaitingFinalReview   │
+  └───────────┬────────────┘
+              │ (final reviewer claims)
+              ▼
+       ┌─────────────┐
+       │ FinalReview │
+       └──┬──────┬───┘
+(approve) │      │ (reject)
+          │      ▼
+          │   ┌──────────┐
+          │   │ Rejected │──► InProgress (re-assigned to annotator)
+          │   └──────────┘
+          ▼
+     ┌───────────┐
+     │ Completed │  ← Gold Standard
+     └───────────┘
+```
+
+### State Reference
+
+| State | Meaning |
+|---|---|
+| `pending` | Task created, not yet assigned |
+| `in_progress` | Assigned to an Annotator, being corrected |
+| `awaiting_review` | Annotator submitted, waiting for a Reviewer to claim |
+| `in_review` | Reviewer has claimed and is reviewing |
+| `awaiting_final_review` | Reviewer approved, waiting for a Final Reviewer to claim |
+| `final_review` | Final Reviewer has claimed and is reviewing |
+| `completed` | Final Reviewer approved — Gold Standard |
+| `rejected` | Rejected by Reviewer or Final Reviewer, re-queued for Annotator |
+
+### Rejection Flow
+
+When a task is rejected (at either review tier), it transitions back to `rejected` and is then re-assigned to its original Annotator as `in_progress`. The rejection comment and actor are recorded in the task's audit history. The Annotator can see the rejection reason in the workspace sidebar before making corrections.
+
+Each task tracks independent counters for annotation rejections and review rejections, surfaced in the Admin batch view.
+
+## Task Actions (Audit Trail)
+
+Every state change is recorded as an immutable history entry. Actions available:
+
+| Action | Triggered by |
+|---|---|
+| `created` | Admin uploads batch |
+| `assigned` | Admin or system assigns task |
+| `started` | Annotator opens task |
+| `submitted` | Annotator submits corrected text |
+| `claimed_for_review` | Reviewer picks up task |
+| `approved` | Reviewer approves |
+| `rejected` | Reviewer rejects |
+| `claimed_for_final_review` | Final Reviewer picks up task |
+| `final_approved` | Final Reviewer approves |
+| `final_rejected` | Final Reviewer rejects |
+| `reassigned` | Admin reassigns task manually |
+| `text_updated` | Annotator saves a draft |
+
+## Workspace Editor
+
+The workspace is the primary working view for Annotators, Reviewers, and Final Reviewers.
+
+**Layout**: The image viewer occupies the left panel; the text editor occupies the right. A sidebar shows task metadata, history, and navigation.
+
+**Image Viewer**:
+- Pan and zoom with mouse or trackpad
+- TIFF files are supported (decoded in-browser via `utif2`)
+- Keyboard shortcuts: `Ctrl/Cmd + +/-/0`
+
+**Text Editor**:
+- Font family and size are configurable per user (persisted in localStorage)
+- Drafts auto-saved with `Ctrl/Cmd + S`
+- Submit and Approve/Reject actions are in the toolbar
+
+## Admin Workflows
+
+### Batch Upload
+
+1. Go to **Admin → Batches → Create Batch**.
+2. Upload a CSV or JSON file containing task entries (`name`, `url`, `transcript`).
+3. Assign the batch to a **Group**.
+4. Tasks are created in bulk and enter the `pending` state.
+
+### User Management
+
+1. Go to **Admin → Users**.
+2. Create a user by email — they receive an Auth0 invitation.
+3. Assign a **Role** and a **Group** (optional).
+4. Users can be updated or removed at any time.
+
+### Group Management
+
+Groups organize users and batches together. A user belongs to one group; a batch is assigned to one group. This allows admins to scope work to specific teams.


### PR DESCRIPTION
…ing)

- Overhaul README.md with quick start, tech stack table, and links to docs/
- Add docs/getting-started.md covering env vars, Auth0 setup, and scripts
- Add docs/architecture.md covering folder structure, state management, routing, and S3 proxy
- Add docs/workflows.md covering user roles, task state machine, audit trail, and admin workflows
- Add CONTRIBUTING.md covering branching, PR guidelines, code conventions, and naming rules