### PR TITLE
new feat added for the reviewer of the line alignment

### DIFF
--- a/src/features/workspace/components/editor-toolbar.tsx
+++ b/src/features/workspace/components/editor-toolbar.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Eraser, Type, ALargeSmall, RotateCcw } from 'lucide-react'
+import { Eraser, Type, ALargeSmall, RotateCcw, GitCompare, PenLine } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -20,6 +20,10 @@ type EditorToolbarProps = {
   hasContent: boolean
   hasOriginalContent: boolean
   isDisabled?: boolean
+  // Diff view props — only used for reviewer role
+  showDiff?: boolean
+  onToggleDiff?: () => void
+  canShowDiff?: boolean
 }
 
 export function EditorToolbar({
@@ -28,6 +32,9 @@ export function EditorToolbar({
   hasContent,
   hasOriginalContent,
   isDisabled = false,
+  showDiff = false,
+  onToggleDiff,
+  canShowDiff = false,
 }: EditorToolbarProps) {
   const { t } = useTranslation('workspace')
   const {
@@ -134,8 +141,40 @@ export function EditorToolbar({
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Restore Original Button */}
-      {hasOriginalContent && (
+      {/* Compare / Edit toggle — reviewer only */}
+      {canShowDiff && onToggleDiff && (
+        <>
+          <Button
+            id="diff-toggle-btn"
+            variant={showDiff ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={onToggleDiff}
+            className={cn(
+              'h-8 px-3 text-xs transition-colors gap-1.5',
+              showDiff
+                ? 'bg-primary/10 text-primary hover:bg-primary/20 border border-primary/30'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+            aria-label={showDiff ? t('editor.editMode') : t('editor.compareMode')}
+          >
+            {showDiff ? (
+              <>
+                <PenLine className="h-3.5 w-3.5" />
+                {t('editor.editMode')}
+              </>
+            ) : (
+              <>
+                <GitCompare className="h-3.5 w-3.5" />
+                {t('editor.compareMode')}
+              </>
+            )}
+          </Button>
+          <Separator orientation="vertical" className="h-5" />
+        </>
+      )}
+
+      {/* Restore Original Button — hidden when in diff mode */}
+      {hasOriginalContent && !showDiff && (
         <>
           <Button
             variant="ghost"
@@ -152,24 +191,25 @@ export function EditorToolbar({
         </>
       )}
 
-      {/* Clear Button */}
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={handleClear}
-        disabled={isDisabled || !hasContent}
-        className={cn(
-          'h-8 px-3 text-xs transition-colors',
-          hasContent
-            ? 'text-muted-foreground hover:text-destructive hover:bg-destructive/10'
-            : 'text-muted-foreground/50'
-        )}
-        aria-label={t('editor.clear')}
-      >
-        <Eraser className="h-3.5 w-3.5 mr-1.5" />
-        {t('editor.clear')}
-      </Button>
+      {/* Clear Button — hidden when in diff mode */}
+      {!showDiff && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleClear}
+          disabled={isDisabled || !hasContent}
+          className={cn(
+            'h-8 px-3 text-xs transition-colors',
+            hasContent
+              ? 'text-muted-foreground hover:text-destructive hover:bg-destructive/10'
+              : 'text-muted-foreground/50'
+          )}
+          aria-label={t('editor.clear')}
+        >
+          <Eraser className="h-3.5 w-3.5 mr-1.5" />
+          {t('editor.clear')}
+        </Button>
+      )}
     </div>
   )
 }
-

--- a/src/features/workspace/components/index.ts
+++ b/src/features/workspace/components/index.ts
@@ -5,4 +5,4 @@ export * from './trash-confirmation-dialog'
 export * from './empty-tasks-state'
 export * from './editor-overlay'
 export * from './editor-toolbar'
-
+export * from './transcript-diff-viewer'

--- a/src/features/workspace/components/transcript-diff-viewer.tsx
+++ b/src/features/workspace/components/transcript-diff-viewer.tsx
@@ -1,0 +1,289 @@
+import { useMemo, Fragment } from 'react'
+import { diff_match_patch, DIFF_DELETE, DIFF_INSERT, DIFF_EQUAL } from 'diff-match-patch'
+import { cn } from '@/lib/utils'
+import { FONT_FAMILY_MAP } from './constant'
+import type { EditorFontFamily } from '@/store/use-ui-store'
+
+interface TranscriptDiffViewerProps {
+  initialTranscript: string
+  annotatorTranscript: string
+  reviewerTranscript: string
+  fontFamily: EditorFontFamily
+  fontSize: number
+}
+
+function buildDiffedSegments(original: string, annotated: string) {
+  const dmp = new diff_match_patch()
+  const diffs = dmp.diff_main(original, annotated)
+  dmp.diff_cleanupSemantic(diffs)
+  return diffs
+}
+
+function renderTextWithNewlines(text: string) {
+  const parts = text.split('\n')
+  return (
+    <Fragment>
+      {parts.map((part, index) => (
+        <Fragment key={index}>
+          {part}
+          {index < parts.length - 1 && (
+            <Fragment>
+              <span className="inline-block mx-1 select-none font-sans text-[0.85em] opacity-80" aria-hidden="true">
+                ↵
+              </span>
+              {'\n'}
+            </Fragment>
+          )}
+        </Fragment>
+      ))}
+    </Fragment>
+  )
+}
+
+interface CharInfo {
+  char: string
+  isAnnotatorAdded: boolean
+}
+
+type RenderSegment =
+  | { text: string; type: 'default' }
+  | { text: string; type: 'annotator_added' }
+  | { text: string; type: 'reviewer_added' }
+  | { text: string; type: 'reviewer_deleted' }
+
+export function TranscriptDiffViewer({
+  initialTranscript,
+  annotatorTranscript,
+  reviewerTranscript,
+  fontFamily,
+  fontSize,
+}: TranscriptDiffViewerProps) {
+  
+  // 1. Diffs between Original OCR and Annotator's Version
+  const diffsAB = useMemo(
+    () => buildDiffedSegments(initialTranscript, annotatorTranscript),
+    [initialTranscript, annotatorTranscript]
+  )
+
+  // 2. Diffs between Annotator's Version and Reviewer's Version
+  const diffsBC = useMemo(
+    () => buildDiffedSegments(annotatorTranscript, reviewerTranscript),
+    [annotatorTranscript, reviewerTranscript]
+  )
+
+  // Top Pane segments (Original OCR)
+  const topSegments = diffsAB
+    .filter((d) => d[0] === DIFF_EQUAL || d[0] === DIFF_DELETE)
+    .map((d) => ({ text: d[1], type: d[0] }))
+
+  // Build character map for Annotator's Version (B)
+  const bChars = useMemo(() => {
+    const chars: CharInfo[] = []
+    for (const [type, text] of diffsAB) {
+      if (type === DIFF_EQUAL) {
+        for (const char of text) {
+          chars.push({ char, isAnnotatorAdded: false })
+        }
+      } else if (type === DIFF_INSERT) {
+        for (const char of text) {
+          chars.push({ char, isAnnotatorAdded: true })
+        }
+      }
+    }
+    return chars
+  }, [diffsAB])
+
+  // Bottom Pane segments (Reviewer's current text + deleted text)
+  const bottomSegments = useMemo(() => {
+    const segments: RenderSegment[] = []
+    let bIndex = 0
+
+    for (const [type, text] of diffsBC) {
+      if (type === DIFF_INSERT) {
+        segments.push({ text, type: 'reviewer_added' })
+      } else if (type === DIFF_DELETE) {
+        segments.push({ text, type: 'reviewer_deleted' })
+        bIndex += text.length
+      } else if (type === DIFF_EQUAL) {
+        if (text.length === 0) continue
+
+        let currentFlag = bChars[bIndex]?.isAnnotatorAdded ?? false
+        let currentText = ''
+
+        for (let i = 0; i < text.length; i++) {
+          const charInfo = bChars[bIndex + i]
+          // Fail-safe if charInfo is somehow undefined
+          if (!charInfo) {
+            currentText += text[i]
+            continue
+          }
+
+          if (charInfo.isAnnotatorAdded === currentFlag) {
+            currentText += charInfo.char
+          } else {
+            segments.push({
+              text: currentText,
+              type: currentFlag ? 'annotator_added' : 'default',
+            })
+            currentFlag = charInfo.isAnnotatorAdded
+            currentText = charInfo.char
+          }
+        }
+        if (currentText.length > 0) {
+          segments.push({
+            text: currentText,
+            type: currentFlag ? 'annotator_added' : 'default',
+          })
+        }
+        bIndex += text.length
+      }
+    }
+    return segments
+  }, [diffsBC, bChars])
+
+  const sharedStyle: React.CSSProperties = {
+    fontFamily: FONT_FAMILY_MAP[fontFamily],
+    fontSize: `${fontSize}px`,
+    lineHeight: 1.8,
+  }
+
+  // Check if there are changes to display the "Changes detected" badge
+  const hasAnnotatorChanges = diffsAB.some((d) => d[0] !== DIFF_EQUAL)
+  const hasReviewerChanges = diffsBC.some((d) => d[0] !== DIFF_EQUAL)
+  const hasChanges = hasAnnotatorChanges || hasReviewerChanges
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Top: Original OCR */}
+      <div className="flex flex-col flex-1 min-h-0 border-b border-border">
+        {/* Header */}
+        <div className="flex items-center gap-2 px-4 py-2 bg-card/60 shrink-0 border-b border-border">
+          <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <span className="inline-block w-2 h-2 rounded-full bg-rose-500/80" />
+            Original OCR
+          </span>
+        </div>
+        {/* Content */}
+        <div className="overflow-auto p-5 bg-rose-50/30 dark:bg-rose-950/10 flex-1">
+          <p
+            className="whitespace-pre-wrap break-words leading-relaxed text-foreground"
+            style={sharedStyle}
+          >
+            {topSegments.map((seg, i) =>
+              seg.type === DIFF_DELETE ? (
+                <mark
+                  key={i}
+                  className={cn(
+                    'bg-rose-200/70 dark:bg-rose-800/50 text-rose-900 dark:text-rose-200',
+                    'rounded px-0.5 ring-1 ring-rose-300 dark:ring-rose-700'
+                  )}
+                >
+                  {renderTextWithNewlines(seg.text)}
+                </mark>
+              ) : (
+                <span key={i}>{renderTextWithNewlines(seg.text)}</span>
+              )
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* Bottom: Current Version */}
+      <div className="flex flex-col flex-1 min-h-0">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-2 px-4 py-2 bg-card/60 shrink-0 border-b border-border">
+          <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <span className="inline-block w-2 h-2 rounded-full bg-blue-500/80" />
+            Current Version
+          </span>
+          {!hasChanges && (
+            <span className="text-xs text-emerald-600 dark:text-emerald-400 font-medium bg-emerald-50 dark:bg-emerald-950/40 px-2 py-0.5 rounded-full">
+              ✓ No changes
+            </span>
+          )}
+          {hasChanges && (
+            <span className="text-xs text-amber-600 dark:text-amber-400 font-medium bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 rounded-full">
+              Changes detected
+            </span>
+          )}
+        </div>
+        {/* Content */}
+        <div className="overflow-auto p-5 bg-blue-50/10 dark:bg-blue-950/10 flex-1">
+          <p
+            className="whitespace-pre-wrap break-words leading-relaxed text-foreground"
+            style={sharedStyle}
+          >
+            {bottomSegments.map((seg, i) => {
+              if (seg.type === 'annotator_added') {
+                return (
+                  <mark
+                    key={i}
+                    className={cn(
+                      'bg-emerald-200/70 dark:bg-emerald-800/50 text-emerald-900 dark:text-emerald-200',
+                      'rounded px-0.5 ring-1 ring-emerald-300 dark:ring-emerald-700'
+                    )}
+                  >
+                    {renderTextWithNewlines(seg.text)}
+                  </mark>
+                )
+              }
+              if (seg.type === 'reviewer_added') {
+                return (
+                  <mark
+                    key={i}
+                    className={cn(
+                      'bg-blue-200/70 dark:bg-blue-800/50 text-blue-900 dark:text-blue-200',
+                      'rounded px-0.5 ring-1 ring-blue-300 dark:ring-blue-700'
+                    )}
+                  >
+                    {renderTextWithNewlines(seg.text)}
+                  </mark>
+                )
+              }
+              if (seg.type === 'reviewer_deleted') {
+                return (
+                  <mark
+                    key={i}
+                    className={cn(
+                      'bg-orange-200/50 dark:bg-orange-800/30 text-orange-800 dark:text-orange-300',
+                      'rounded px-0.5 line-through opacity-70'
+                    )}
+                  >
+                    {renderTextWithNewlines(seg.text)}
+                  </mark>
+                )
+              }
+              return <span key={i}>{renderTextWithNewlines(seg.text)}</span>
+            })}
+          </p>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-4 px-4 py-2 border-t border-border bg-card/60 shrink-0 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded bg-rose-200/70 dark:bg-rose-800/50 ring-1 ring-rose-300 dark:ring-rose-700" />
+          Deleted from OCR
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded bg-emerald-200/70 dark:bg-emerald-800/50 ring-1 ring-emerald-300 dark:ring-emerald-700" />
+          Added by Annotator
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded bg-blue-200/70 dark:bg-blue-800/50 ring-1 ring-blue-300 dark:ring-blue-700" />
+          Added by You
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded bg-orange-200/50 dark:bg-orange-800/30 line-through opacity-70" style={{ textDecorationColor: 'currentColor' }}>
+            <span className="opacity-0">x</span>
+          </span>
+          Deleted by You
+        </span>
+        <span className="flex items-center gap-1.5 ml-auto">
+          <span className="inline-block opacity-80 text-[1.2em]">↵</span>
+          Line break
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/workspace/components/workspace-editor.tsx
+++ b/src/features/workspace/components/workspace-editor.tsx
@@ -7,6 +7,7 @@ import { TrashConfirmationDialog } from './trash-confirmation-dialog'
 import { EditorOverlay } from './editor-overlay'
 import { EditorToolbar } from './editor-toolbar'
 import { EmptyTasksState } from './empty-tasks-state'
+import { TranscriptDiffViewer } from './transcript-diff-viewer'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAuth } from '@/features/auth'
@@ -31,9 +32,11 @@ export function WorkspaceEditor() {
   // State
   const [text, setText] = useState('')
   const [originalOcrText, setOriginalOcrText] = useState('')
+  const [initialTranscript, setInitialTranscript] = useState('')
   const [splitPosition, setSplitPosition] = useState(50)
   const [isDragging, setIsDragging] = useState(false)
   const [trashDialogOpen, setTrashDialogOpen] = useState(false)
+  const [showDiff, setShowDiff] = useState(false)
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -63,20 +66,34 @@ export function WorkspaceEditor() {
   const isLoadingNextTask = isFetching && !isLoading
   const showOverlay = isLoadingNextTask || isMutating
 
+  // Reviewer role check
+  const isReviewer =
+    currentUser?.role === UserRole.Reviewer ||
+    currentUser?.role === UserRole.FinalReviewer
+
+  // Can show diff only for reviewers when initial_transcript exists
+  const canShowDiff =
+    isReviewer &&
+    !!task?.initial_transcript &&
+    task.initial_transcript.trim().length > 0
+
   // Track task ID to detect task changes
   const [currentTaskId, setCurrentTaskId] = useState<string | null>(null)
 
   // Load task text when task changes (restore from local draft if available)
   if (task && task.task_id !== currentTaskId) {
     setCurrentTaskId(task.task_id)
-    // Restore from local draft if available, otherwise use server transcript
     const restoredText = savedDraft ?? task.task_transcript ?? ''
     setText(restoredText)
     setOriginalOcrText(task.task_transcript ?? '')
+    setInitialTranscript(task.initial_transcript ?? '')
+    setShowDiff(false) // reset diff view on new task
   } else if (!task && currentTaskId !== null) {
     setCurrentTaskId(null)
     setText('')
     setOriginalOcrText('')
+    setInitialTranscript('')
+    setShowDiff(false)
   }
 
   // Clear handler for toolbar
@@ -88,6 +105,11 @@ export function WorkspaceEditor() {
   const handleRestoreOriginal = useCallback(() => {
     setText(originalOcrText)
   }, [originalOcrText])
+
+  // Diff toggle handler
+  const handleToggleDiff = useCallback(() => {
+    setShowDiff((prev) => !prev)
+  }, [])
 
   // Submit handler
   const handleSubmit = useCallback(() => {
@@ -193,7 +215,7 @@ export function WorkspaceEditor() {
 
   // Track orientation changes to reset split position
   const [lastOrientation, setLastOrientation] = useState<string | undefined>(undefined)
-  
+
   // Reset split position to 50% when orientation changes
   if (task?.orientation !== lastOrientation) {
     setLastOrientation(task?.orientation)
@@ -336,31 +358,45 @@ export function WorkspaceEditor() {
               hasContent={text.length > 0}
               hasOriginalContent={originalOcrText.length > 0 && text !== originalOcrText}
               isDisabled={!canEdit || showOverlay}
+              canShowDiff={canShowDiff}
+              showDiff={showDiff}
+              onToggleDiff={handleToggleDiff}
             />
 
-            {/* Textarea */}
-            <textarea
-              id="editor-textarea"
-              name="editor-textarea"
-              ref={textareaRef}
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              readOnly={!canEdit || showOverlay}
-              placeholder={t('editor.placeholder')}
-              className={cn(
-                'flex-1 w-full resize-none bg-card p-5',
-                'text-foreground placeholder:text-placeholder',
-                'focus:outline-none focus:ring-0',
-                'transition-all duration-200',
-                (!canEdit || showOverlay) && 'cursor-default opacity-80'
-              )}
-              style={{
-                fontFamily: FONT_FAMILY_MAP[editorFontFamily],
-                fontSize: `${editorFontSize}px`,
-                lineHeight: 1.6,
-              }}
-              spellCheck={false}
-            />
+            {/* Diff Viewer (reviewer only, when toggled on) */}
+            {showDiff && canShowDiff ? (
+              <TranscriptDiffViewer
+                initialTranscript={initialTranscript}
+                annotatorTranscript={originalOcrText}
+                reviewerTranscript={text}
+                fontFamily={editorFontFamily}
+                fontSize={editorFontSize}
+              />
+            ) : (
+              /* Textarea */
+              <textarea
+                id="editor-textarea"
+                name="editor-textarea"
+                ref={textareaRef}
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                readOnly={!canEdit || showOverlay}
+                placeholder={t('editor.placeholder')}
+                className={cn(
+                  'flex-1 w-full resize-none bg-card p-5',
+                  'text-foreground placeholder:text-placeholder',
+                  'focus:outline-none focus:ring-0',
+                  'transition-all duration-200',
+                  (!canEdit || showOverlay) && 'cursor-default opacity-80'
+                )}
+                style={{
+                  fontFamily: FONT_FAMILY_MAP[editorFontFamily],
+                  fontSize: `${editorFontSize}px`,
+                  lineHeight: 1.6,
+                }}
+                spellCheck={false}
+              />
+            )}
           </div>
         </div>
 

--- a/src/locales/bo/workspace.json
+++ b/src/locales/bo/workspace.json
@@ -6,7 +6,9 @@
     "unsavedChanges": "མ་ཉར་བའི་བཅོས་བསྒྱུར།",
     "cleared": "ཡི་གེ་བསྒྱུར་བ་གཙང་བཟོས།",
     "clearedDescription": "ཡི་གེའི་ས་ཁོངས་གཙང་བཟོས།",
-    "undo": "ཕྱིར་འཐེན།"
+    "undo": "ཕྱིར་འཐེན།",
+    "compareMode": "དཔེ་བསྡུར།",
+    "editMode": "རྩོམ་སྒྲིག"
   },
   "imageCanvas": {
     "sourceImage": "སྒོ་ནས་སྒྲིག།",

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -6,7 +6,9 @@
     "unsavedChanges": "Unsaved changes",
     "cleared": "Transcription cleared",
     "clearedDescription": "The text area has been cleared",
-    "undo": "Undo"
+    "undo": "Undo",
+    "compareMode": "Compare",
+    "editMode": "Edit"
   },
   "imageCanvas": {
     "sourceImage": "Source Image",

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -97,6 +97,7 @@ export interface AssignedTask {
   task_name: string
   task_url: string
   task_transcript: string
+  initial_transcript?: string
   state: 'annotating' | 'submitted' | 'reviewing' | 'finalising' | 'completed' | 'trashed'
   batch_name: string
   group: string


### PR DESCRIPTION
### Problem: 

Right now, the reviewer only has access to the annotated data. What we want is for the reviewer to have access to both the initial/original data and the annotated/modified data.

By comparing the two versions, reviewers will be able to easily identify what changes were made during annotation. This is especially important for tools like the line alignment tool, where annotators may accidentally remove a letter or word, or modify the alignment. Currently, reviewers have no simple way to detect these changes because only the final annotated version is visible.


### Solution 

To solve this problem, we implemented a comparison mechanism (diff view/change tracking) between the original OCR text, the annotator’s version, and the reviewer’s live edits.

Since standard diff algorithms only compare two texts at a time, we used Google’s diff-match-patch library to create a pseudo 3-way comparison:

Original OCR (initialTranscript)
Annotator Version (annotatorTranscript)
Reviewer Version (reviewerTranscript)

First, we compare the original OCR with the annotator’s version and build a character-level map to identify which characters were added by the annotator.

Next, we compare the annotator’s version with the reviewer’s current text. Using the previously built character map, we can visually distinguish:

Annotator add - green
Reviewer add - blue
Reviewer removed - Orange & strike
Unchanged - Normal

We also made line breaks visible by rendering a ↵ symbol for newline characters, allowing formatting and alignment changes to be reviewed more easily.

The original OCR and annotator versions come from the backend/database, while the reviewer version exists in React local state, enabling real-time diff updates as the reviewer types.


### Video sample

https://github.com/user-attachments/assets/a2419228-da86-4763-b2c9-30e57b02d28a

